### PR TITLE
Update zebrunner_logging.py

### DIFF
--- a/src/pytest_zebrunner/zebrunner_logging.py
+++ b/src/pytest_zebrunner/zebrunner_logging.py
@@ -42,7 +42,7 @@ class ZebrunnerHandler(StreamHandler):
                     test_id=str(zebrunner_context.test_id),
                     timestamp=str(round(time.time() * 1000)),
                     level=record.levelname,
-                    message=record.msg,
+                    message=str(record.msg),
                 )
             )
 


### PR DESCRIPTION
### Logging Error

### Summary
Converting message to str.

### Reason for change
Error caused when logging dict objects

Staying consistent with logging package, convert any provided message (dict, int, etc.) to str. This prevents the below error.
`E   pydantic.error_wrappers.ValidationError: 1 validation error for LogRecordModel
E   message
E     str type expected (type=type_error.str)`